### PR TITLE
Support namespaced records for inet_contains

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,6 +69,11 @@ namespace :db do
         t.datetime "updated_at"
       end
 
+      create_table :namespaced_records, force: true do |t|
+        t.inet "ip"
+        t.cidr "subnet"
+      end
+
       create_table :tags, force: true do |t|
         t.belongs_to :user, index: true, foreign_key: true
         t.integer :tag_number, default: 0

--- a/lib/active_record_extended/arel/nodes.rb
+++ b/lib/active_record_extended/arel/nodes.rb
@@ -35,6 +35,7 @@ module Arel
 
     module Inet
       %w[
+        Contains
         ContainsEquals
         ContainedWithin
         ContainedWithinEquals

--- a/lib/active_record_extended/arel/predications.rb
+++ b/lib/active_record_extended/arel/predications.rb
@@ -21,10 +21,13 @@ module Arel
     def contains(other)
       Nodes::Contains.new self, Nodes.build_quoted(other, self)
     end
-    alias inet_contains contains
 
     def contained_in_array(other)
       Nodes::ContainedInArray.new self, Nodes.build_quoted(other, self)
+    end
+
+    def inet_contains(other)
+      Nodes::Inet::Contains.new self, Nodes.build_quoted(other, self)
     end
 
     def inet_contains_or_is_contained_within(other)

--- a/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
+++ b/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
@@ -23,7 +23,7 @@ module ActiveRecordExtended
         elsif left_column.try(:array)
           visit_Arel_Nodes_ContainsArray(object, collector)
         else
-          infix_value object, collector, " >> "
+          visit_Arel_Nodes_Inet_Contains(object, collector)
         end
       end
 
@@ -92,6 +92,10 @@ module ActiveRecordExtended
         else
           collector
         end
+      end
+
+      def visit_Arel_Nodes_Inet_Contains(object, collector)
+        infix_value object, collector, " >> "
       end
 
       def visit_Arel_Nodes_Inet_ContainedWithinEquals(object, collector)

--- a/lib/active_record_extended/query_methods/inet.rb
+++ b/lib/active_record_extended/query_methods/inet.rb
@@ -57,7 +57,7 @@ module ActiveRecordExtended
       #  #=> "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"ip\" >> '127.0.0.255/32'"
       #
       def inet_contains(opts, *rest)
-        substitute_comparisons(opts, rest, Arel::Nodes::Contains, "inet_contains")
+        substitute_comparisons(opts, rest, Arel::Nodes::Inet::Contains, "inet_contains")
       end
 
       # This method is a combination of `inet_contains` and `inet_contained_within`

--- a/spec/query_methods/inet_query_spec.rb
+++ b/spec/query_methods/inet_query_spec.rb
@@ -3,6 +3,8 @@
 require "spec_helper"
 
 RSpec.describe "Active Record Inet Query Methods" do
+  before { stub_const('User', Namespaced::Record) }
+
   describe "#inet_contained_within" do
     let!(:local_1)     { User.create!(ip: "127.0.0.1") }
     let!(:local_44)    { User.create!(ip: "127.0.0.44") }

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -20,6 +20,19 @@ class User < ApplicationRecord
   #
 end
 
+module Namespaced 
+  def self.table_name_prefix
+    'namespaced_'
+  end
+
+  class Record < ApplicationRecord
+    # attributes
+    # t.inet :ip
+    # t.cidr :subnet
+    #
+  end
+end
+
 class Tag < ApplicationRecord
   belongs_to :user
   # attributes: tag_number


### PR DESCRIPTION
I'm not entirely sure why `inet_contains` generated an `Arel::Nodes::Contains` node, but this creates an `Arel::Nodes::Inet::Contains` node to bypass the const lookup from table name.

Closes #25 