### PR TITLE
Reduce object creation by stepping away from `&method` short hand notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.4.0 - (Unreleased)
+
+Performance tweaks:
+ - Reduce object creations when using the ruby shorthand `&method()`.
+
 # 1.3.1 - October 2nd 2019
 
 Bug fix:

--- a/lib/active_record_extended/query_methods/json.rb
+++ b/lib/active_record_extended/query_methods/json.rb
@@ -51,7 +51,7 @@ module ActiveRecordExtended
         private
 
         def build_json_literal(arel_klass, values:, col_alias: DEFAULT_ALIAS)
-          json_values    = flatten_to_sql(values.to_a, &method(:literal_key))
+          json_values    = flatten_to_sql(values.to_a) { |value| literal_key(value) }
           col_alias      = double_quote(col_alias)
           json_build_obj = arel_klass.new(json_values)
           @scope.select(nested_alias_escape(json_build_obj, col_alias))
@@ -117,7 +117,7 @@ module ActiveRecordExtended
               lean_opts.call(:value)     { arg.delete(:value).presence }
               lean_opts.call(:col_alias) { arg.delete(:as) }
               lean_opts.call(:order_by)  { order_by_expression(arg.delete(:order_by)) }
-              lean_opts.call(:from)      { arg.delete(:from).tap(&method(:pipe_cte_with!)) }
+              lean_opts.call(:from)      { arg.delete(:from).tap { |from_clause| pipe_cte_with!(from_clause) } }
               lean_opts.call(:cast_with) { casting_options(arg.delete(:cast_with) || arg.delete(:cast_as_array)) }
             end
 

--- a/lib/active_record_extended/query_methods/select.rb
+++ b/lib/active_record_extended/query_methods/select.rb
@@ -65,7 +65,7 @@ module ActiveRecordExtended
         def hash_to_dot_notation(column)
           case column
           when Hash, Array
-            column.to_a.flat_map(&method(:hash_to_dot_notation)).join(".")
+            column.to_a.flat_map { |col| hash_to_dot_notation(col) }.join(".")
           when String, Symbol
             /^([[:alpha:]]+)$/.match?(column.to_s) ? double_quote(column) : column
           else
@@ -92,7 +92,7 @@ module ActiveRecordExtended
           when "array", "true"
             wrap_with_array(query, alias_name)
           when AGGREGATE_ONE_LINERS
-            expr         = to_sql_array(query, &method(:group_when_needed))
+            expr         = to_sql_array(query) { |value| group_when_needed(value) }
             casted_query = ::Arel::Nodes::AggregateFunctionName.new(cast_with, expr, distinct).order_by(order_expr)
             nested_alias_escape(casted_query, alias_name)
           else

--- a/lib/active_record_extended/query_methods/unionize.rb
+++ b/lib/active_record_extended/query_methods/unionize.rb
@@ -59,7 +59,7 @@ module ActiveRecordExtended
         protected
 
         def append_union_order!(union_type, args)
-          args.each(&method(:pipe_cte_with!))
+          args.each { |arg| pipe_cte_with!(arg) }
           flatten_scopes       = flatten_to_sql(args)
           @scope.union_values += flatten_scopes
           calculate_union_operation!(union_type, flatten_scopes.size)

--- a/lib/active_record_extended/utilities/order_by.rb
+++ b/lib/active_record_extended/utilities/order_by.rb
@@ -24,8 +24,8 @@ module ActiveRecordExtended
         return false unless order_by && order_by.presence.present?
 
         to_ordered_table_path(order_by)
-          .tap(&method(:process_ordering_arguments!))
-          .tap(&method(:scope_preprocess_order_args))
+          .tap { |order_args| process_ordering_arguments!(order_args) }
+          .tap { |order_args| scope_preprocess_order_args(order_args) }
       end
 
       #

--- a/lib/active_record_extended/utilities/support.rb
+++ b/lib/active_record_extended/utilities/support.rb
@@ -172,7 +172,7 @@ module ActiveRecordExtended
       end
 
       def generate_named_function(function_name, *args)
-        args.map!(&method(:to_arel_sql))
+        args.map! { |arg| to_arel_sql(arg) }
         function_name = function_name.to_s.upcase
         ::Arel::Nodes::NamedFunction.new(to_arel_sql(function_name), args)
       end


### PR DESCRIPTION
After reading: https://mensfeld.pl/2019/11/the-hidden-cost-of-the-ruby-2-7-dot-colon-method-reference-usage/

I came to realize that while quick and easy, the `method()` ruby function is also creating a lot of useless objects. What I assumed was simply syntactic-sugar for basic blocks was actually more then what I was expecting.

Example script and outcome:

```ruby
def get_object_id(obj)
  obj.object_id
end

a = [1, 2]
tao1 =  GC.stat[:total_allocated_objects]

a.map { |d| get_object_id(d) }

tao2 =  GC.stat[:total_allocated_objects]

a.map(&method(:get_object_id))

tao3 =  GC.stat[:total_allocated_objects]

pp "Map with blocks: #{tao2 - tao1}"
pp "Map with &method: #{tao3 - tao2}"
```

Produces:

```
"Map with blocks: 3"
"Map with &method: 6"
```

Flipping which method gets ran first does not effect it. (in-fact it generates 10 objects if `&method` is first)