### PR TITLE
Fixes breakage in Rails 6.1

### DIFF
--- a/lib/active_record_extended/utilities/support.rb
+++ b/lib/active_record_extended/utilities/support.rb
@@ -149,7 +149,7 @@ module ActiveRecordExtended
 
       def to_arel_sql(value)
         case value
-        when Arel::Node, Arel::Nodes::SqlLiteral, nil
+        when Arel::Nodes, Arel::Nodes::SqlLiteral, nil
           value
         when ActiveRecord::Relation
           Arel.sql(value.spawn.to_sql)


### PR DESCRIPTION
After upgrading to Rails Edge recently this library stopped working for me because `Arel::Node` doesn't exist. I invested about 20 minutes into trying to figure out what `Arel::Node` is or was, and couldn't find anything about it. I'm sorry to not supply additional details or testing information, but I just don't have more time to invest into it. My patch got it working again.