### PR TITLE
Either joins with has_many through association

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,6 +97,14 @@ namespace :db do
         t.references :versionable, polymorphic: true, index: true, null: false
         t.jsonb :source, default: {}, null: false
       end
+
+      create_table :groups, force: true do |t|
+      end
+
+      create_table :groups_users, force: true do |t|
+        t.belongs_to :user, index: true, foreign_key: true
+        t.belongs_to :group, index: true, foreign_key: true
+      end
     end
 
     puts "Database migrated"

--- a/lib/active_record_extended/query_methods/either.rb
+++ b/lib/active_record_extended/query_methods/either.rb
@@ -52,6 +52,7 @@ module ActiveRecordExtended
       def xor_field_options_for_associations(associations)
         associations.each_with_object({}) do |association_name, options|
           reflection = reflect_on_association(association_name)
+          reflection = reflection.through_reflection if reflection.through_reflection?
           options[reflection.table_name] = reflection.foreign_key
         end
       end

--- a/spec/query_methods/either_spec.rb
+++ b/spec/query_methods/either_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe "Active Record Either Methods" do
         expect(query).to_not include(three)
       end
     end
+
+    context "Through association .either_joins/2" do
+      let!(:four) { User.create! }
+      let!(:group) { Group.create!(users: [four]) }
+
+      it "Should only only return records that belong to profile L or has group" do
+        query = User.either_joins(:profile_l, :groups)
+        expect(query).to include(one, four)
+        expect(query).to_not include(three, two)
+      end
+    end
   end
 
   describe ".either_order/2" do

--- a/spec/sql_inspections/either_sql_spec.rb
+++ b/spec/sql_inspections/either_sql_spec.rb
@@ -31,6 +31,22 @@ RSpec.describe "Either Methods SQL Queries" do
       query = User.either_join(:profile_l, :profile_r).to_sql
       expect(query).to include(where_join_case)
     end
+
+    context "Through association .either_joins/2" do
+      let!(:four) { User.create! }
+      let!(:group) { Group.create!(users: [four]) }
+      let(:where_join_through_case) do
+        "WHERE ((CASE WHEN profile_ls.user_id IS NULL"\
+        " THEN groups_users.user_id"\
+        " ELSE profile_ls.user_id END) "\
+        "= users.id)"
+      end
+
+      it "Should contain a case statement that will conditionally alternative between tables" do
+        query = User.either_join(:profile_l, :groups).to_sql
+        expect(query).to include(where_join_through_case)
+      end
+    end
   end
 
   describe ".either_order/2" do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -5,6 +5,8 @@ class ApplicationRecord < ActiveRecord::Base
 end
 
 class User < ApplicationRecord
+  has_many :groups_users, class_name: "GroupsUser"
+  has_many :groups, through: :groups_users, dependent: :destroy
   has_many :hm_tags, class_name: "Tag"
   has_one :profile_l, class_name: "ProfileL"
   has_one :profile_r, class_name: "ProfileR"
@@ -65,4 +67,14 @@ class VersionControl < ApplicationRecord
   # attributes
   # t.jsonb :source, default: {}, null: false
   #
+end
+
+class Group < ApplicationRecord
+  has_many :groups_users, class_name: "GroupsUser"
+  has_many :users, through: :groups_users, dependent: :destroy
+end
+
+class GroupsUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :group
 end


### PR DESCRIPTION
### Issue:
When using `either_joins/2` with `has_many through` association, the query fails, because in where condition used final table name, not 'through' table
### Solution
In method `xor_field_options_for_associations` if reflection.through_reflection? use 'through' reflection