### PR TITLE
Avoid loading associations during query building

### DIFF
--- a/lib/active_record_extended/query_methods/unionize.rb
+++ b/lib/active_record_extended/query_methods/unionize.rb
@@ -107,7 +107,7 @@ module ActiveRecordExtended
       end
 
       def union(opts = :chain, *args)
-        return UnionChain.new(spawn) if opts == :chain
+        return UnionChain.new(spawn) if :chain == opts
 
         opts.nil? ? self : spawn.union!(opts, *args, chain_method: __callee__)
       end
@@ -121,7 +121,7 @@ module ActiveRecordExtended
       def union!(opts = :chain, *args, chain_method: :union)
         union_chain    = UnionChain.new(self)
         chain_method ||= :union
-        return union_chain if opts == :chain
+        return union_chain if :chain == opts
 
         union_chain.public_send(chain_method, *([opts] + args))
       end

--- a/lib/active_record_extended/query_methods/with_cte.rb
+++ b/lib/active_record_extended/query_methods/with_cte.rb
@@ -113,14 +113,14 @@ module ActiveRecordExtended
 
       # @param [Hash, WithCTE] opts
       def with(opts = :chain, *rest)
-        return WithChain.new(spawn) if opts == :chain
+        return WithChain.new(spawn) if :chain == opts
 
         opts.blank? ? self : spawn.with!(opts, *rest)
       end
 
       # @param [Hash, WithCTE] opts
       def with!(opts = :chain, *_rest)
-        return WithChain.new(self) if opts == :chain
+        return WithChain.new(self) if :chain == opts
 
         tap do |scope|
           scope.cte ||= WithCTE.new(self)


### PR DESCRIPTION
The first argument's #== method was being invoked while building union
and CTE queries.  This caused extra loading of records when this
argument was an association.  (See #== on
https://api.rubyonrails.org/classes/ActiveRecord/Associations/CollectionProxy.html)

Should fix #44.