### PR TITLE
Defer extending Either onto ActiveRecord until ActiveRecord is loaded

### DIFF
--- a/lib/active_record_extended/query_methods/either.rb
+++ b/lib/active_record_extended/query_methods/either.rb
@@ -60,4 +60,6 @@ module ActiveRecordExtended
   end
 end
 
-ActiveRecord::Base.extend(ActiveRecordExtended::QueryMethods::Either)
+ActiveSupport.on_load :active_record do
+  extend(ActiveRecordExtended::QueryMethods::Either)
+end


### PR DESCRIPTION
ActiveRecord::Base is lazily loaded by Rails and we don't want to
prematurely load it, otherwise it may be loaded before initialization
runs, then any configuration set in initialization is not copied over to
ActiveRecord::Base internally.