### PR TITLE
Question: Add exists_all/exists_any for jsonb/hstore columns

### DIFF
--- a/lib/active_record_extended/arel/nodes.rb
+++ b/lib/active_record_extended/arel/nodes.rb
@@ -11,6 +11,7 @@ module Arel
 
     [
       "ContainsHStore",
+      "ExistsKeyHStore",
       "ContainsArray",
       "ContainedInArray"
     ].each { |binary_node_name| const_set(binary_node_name, Class.new(::Arel::Nodes::Binary)) }

--- a/lib/active_record_extended/arel/nodes.rb
+++ b/lib/active_record_extended/arel/nodes.rb
@@ -11,7 +11,8 @@ module Arel
 
     [
       "ContainsHStore",
-      "ExistsKeyHStore",
+      "ExistsAllKeysHStore",
+      "ExistsAnyKeysHStore",
       "ContainsArray",
       "ContainedInArray"
     ].each { |binary_node_name| const_set(binary_node_name, Class.new(::Arel::Nodes::Binary)) }

--- a/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
+++ b/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
@@ -35,12 +35,10 @@ module ActiveRecordExtended
         visit object.left, collector
 
         collector << " ?| "
-        collector << "array["
 
-        items = Array(object.right).map { |item| "'#{item.value}'" }
-
-        collector << items.join(", ")
-        collector << "]"
+        collector << "'{"
+        collector << Array(object.right).map(&:value).join(", ")
+        collector << "}'"
 
         collector
       end
@@ -49,12 +47,10 @@ module ActiveRecordExtended
         visit object.left, collector
 
         collector << " ?& "
-        collector << "array["
 
-        items = Array(object.right).map { |item| "'#{item.value}'" }
-
-        collector << items.join(",")
-        collector << "]"
+        collector << "'{"
+        collector << Array(object.right).map(&:value).join(", ")
+        collector << "}'"
 
         collector
       end

--- a/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
+++ b/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
@@ -31,8 +31,32 @@ module ActiveRecordExtended
         infix_value object, collector, " @> "
       end
 
-      def visit_Arel_Nodes_ExistsKeyHStore(object, collector)
-        infix_value object, collector, " ? "
+      def visit_Arel_Nodes_ExistsAnyKeysHStore(object, collector)
+        visit object.left, collector
+
+        collector << " ?| "
+        collector << "array["
+
+        items = Array(object.right).map { |item| "'#{item.value}'" }
+
+        collector << items.join(", ")
+        collector << "]"
+
+        collector
+      end
+
+      def visit_Arel_Nodes_ExistsAllKeysHStore(object, collector)
+        visit object.left, collector
+
+        collector << " ?& "
+        collector << "array["
+
+        items = Array(object.right).map { |item| "'#{item.value}'" }
+
+        collector << items.join(",")
+        collector << "]"
+
+        collector
       end
 
       def visit_Arel_Nodes_ContainsHStore(object, collector)

--- a/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
+++ b/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
@@ -31,6 +31,10 @@ module ActiveRecordExtended
         infix_value object, collector, " @> "
       end
 
+      def visit_Arel_Nodes_ExistsKeyHStore(object, collector)
+        infix_value object, collector, " ? "
+      end
+
       def visit_Arel_Nodes_ContainsHStore(object, collector)
         infix_value object, collector, " @> "
       end

--- a/lib/active_record_extended/query_methods/where_chain.rb
+++ b/lib/active_record_extended/query_methods/where_chain.rb
@@ -26,6 +26,23 @@ module ActiveRecordExtended
       equality_to_function("ALL", opts, rest)
     end
 
+    def exists(opts, *rest)
+      build_where_chain(opts, rest) do |arel|
+        case arel
+        when Arel::Nodes::In, Arel::Nodes::Equality
+          column = left_column(arel) || column_from_association(arel)
+
+          if [:hstore, :jsonb].include?(column.type)
+            Arel::Nodes::ExistsKeyHStore.new(arel.left, arel.right)
+          else
+            raise ArgumentError.new("Invalid argument for .where.exists(), got #{arel.class}")
+          end
+        else
+          raise ArgumentError.new("Invalid argument for .where.exists(), got #{arel.class}")
+        end
+      end
+    end
+
     # Finds Records that contains a nested set elements
     #
     # Array Column Type:

--- a/lib/active_record_extended/query_methods/where_chain.rb
+++ b/lib/active_record_extended/query_methods/where_chain.rb
@@ -27,11 +27,11 @@ module ActiveRecordExtended
     end
 
     def exists_all(opts, *rest)
-      equality_to_key_check(Arel::Nodes::ExistsAllKeysHStore, opts, rest)
+      equality_to_key_check(Arel::Nodes::ExistsAllKeysHStore, __method__, opts, rest)
     end
 
     def exists_any(opts, *rest)
-      equality_to_key_check(Arel::Nodes::ExistsAnyKeysHStore, opts, rest)
+      equality_to_key_check(Arel::Nodes::ExistsAnyKeysHStore, __method__, opts, rest)
     end
 
     # Finds Records that contains a nested set elements
@@ -93,7 +93,7 @@ module ActiveRecordExtended
       @scope.klass.columns_hash[arel.left.name] || @scope.klass.columns_hash[arel.left.relation.name]
     end
 
-    def equality_to_key_check(kind, opts, rest)
+    def equality_to_key_check(kind, method_name, opts, rest)
       build_where_chain(opts, rest) do |arel|
         case arel
         when Arel::Nodes::In, Arel::Nodes::Equality, Arel::Nodes::HomogeneousIn
@@ -102,10 +102,10 @@ module ActiveRecordExtended
           if [:hstore, :jsonb].include?(column.type)
             kind.new(arel.left, arel.right)
           else
-            raise ArgumentError.new("Invalid argument for .where.#{kind}(), got #{arel.class}")
+            raise ArgumentError.new("Invalid argument for .where.#{method_name}(), got #{arel.class}")
           end
         else
-          raise ArgumentError.new("Invalid argument for .where.#{kind}(), got #{arel.class}")
+          raise ArgumentError.new("Invalid argument for .where.#{method_name}(), got #{arel.class}")
         end
       end
     end

--- a/spec/query_methods/hash_query_spec.rb
+++ b/spec/query_methods/hash_query_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe "Active Record Hash Related Query Methods" do
         expect(query).to_not include(two, three)
       end
 
+      it "returns records that contains keys on a given json" do
+        query = User.where.exists(jsonb_data: :payment)
+        expect(query).to include(one, two)
+        expect(query).to_not include(three)
+      end
+
       it "returns records that contain jsonb elements in joined tables" do
         tag_one = Tag.create!(user_id: one.id)
         tag_two = Tag.create!(user_id: two.id)

--- a/spec/query_methods/hash_query_spec.rb
+++ b/spec/query_methods/hash_query_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Active Record Hash Related Query Methods" do
   let!(:one)   { User.create!(data: { nickname: "george" }, jsonb_data: { payment: "zip" }) }
   let!(:two)   { User.create!(data: { nickname: "dan"    }, jsonb_data: { payment: "zipper" }) }
   let!(:three) { User.create!(data: { nickname: "georgey" }) }
+  let!(:four)  { User.create!(data: { nickname: "thomas" }, jsonb_data: { frequency: "monthly" }) }
 
   describe "#contains" do
     context "HStore Column Type" do
@@ -32,9 +33,15 @@ RSpec.describe "Active Record Hash Related Query Methods" do
         expect(query).to_not include(two, three)
       end
 
-      it "returns records that contains keys on a given json" do
-        query = User.where.exists(jsonb_data: :payment)
+      it "returns records that contains all keys on a given json" do
+        query = User.where.exists_all(jsonb_data: [:payment])
         expect(query).to include(one, two)
+        expect(query).to_not include(three)
+      end
+
+      it "returns records that contains any keys on a given json" do
+        query = User.where.exists_any(jsonb_data: [:payment, :frequency])
+        expect(query).to include(one, two, four)
         expect(query).to_not include(three)
       end
 


### PR DESCRIPTION
Implements some other operations from https://www.postgresql.org/docs/9.4/functions-json.html#FUNCTIONS-JSONB-OP-TABLE

First of all thank you for your work on the gem.
We use it extensively and it's fantastic.

From time to time I want to check if a jsonb column has a given set of keys (we use some of them to
enable and disable features)

This is just an initial idea. The AREL build is far from elegant but I wanted to get your feedback
about the concept.

My AREL-fu is not too strong so feel free to correct anything that looks weird.
