### PR TITLE
Deprecate old contains & overlap code for AR 6.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 - Dropped Rails 5.1 support.
 - Dropped Ruby 2.4 support.
+- Arel for ActiveRecord 6.1+ `contains` will no longer accept INET (ip address column types), use `inet_contains` instead.
+  - ActiveRecord `contains` should remain unaffected as it never accepted INET column types. 
 
 #### Bug fixes:
 
 - [#73](https://github.com/GeorgeKaraszi/ActiveRecordExtended/issues/73) [#77](https://github.com/GeorgeKaraszi/ActiveRecordExtended/pull/77) Fix union and window query merging
+- [#74](https://github.com/GeorgeKaraszi/ActiveRecordExtended/issues/74) Fix visitor conflict in Arel 6.1+ and support their native implementation of `contains` and `overlap` functionality
 
 # 2.1.1 - February 14th 2022
 

--- a/lib/active_record_extended/active_record.rb
+++ b/lib/active_record_extended/active_record.rb
@@ -5,6 +5,11 @@ require "active_record/relation"
 require "active_record/relation/merger"
 require "active_record/relation/query_methods"
 
+module ActiveRecordExtended
+  # TODO: Deprecate <= AR 6.0 methods & routines
+  AR_VERSION_GTE_6_1 = Gem::Requirement.new(">= 6.1").satisfied_by?(ActiveRecord.gem_version)
+end
+
 require "active_record_extended/predicate_builder/array_handler_decorator"
 
 require "active_record_extended/active_record/relation_patch"

--- a/lib/active_record_extended/arel/nodes.rb
+++ b/lib/active_record_extended/arel/nodes.rb
@@ -5,7 +5,7 @@ require "arel/nodes/function"
 
 module Arel
   module Nodes
-    if Gem::Requirement.new("< 6.1").satisfied_by?(ActiveRecord.gem_version)
+    unless ActiveRecordExtended::AR_VERSION_GTE_6_1
       ["Contains", "Overlaps"].each { |binary_node_name| const_set(binary_node_name, Class.new(::Arel::Nodes::Binary)) }
     end
 

--- a/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
+++ b/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
@@ -9,21 +9,25 @@ module ActiveRecordExtended
 
       # rubocop:disable Naming/MethodName
 
-      def visit_Arel_Nodes_Overlaps(object, collector)
-        infix_value object, collector, " && "
+      unless ActiveRecordExtended::AR_VERSION_GTE_6_1
+        def visit_Arel_Nodes_Overlaps(object, collector)
+          infix_value object, collector, " && "
+        end
       end
 
-      def visit_Arel_Nodes_Contains(object, collector)
-        left_column = object.left.relation.name.classify.constantize.columns.detect do |col|
-          matchable_column?(col, object)
-        end
+      unless ActiveRecordExtended::AR_VERSION_GTE_6_1
+        def visit_Arel_Nodes_Contains(object, collector)
+          left_column = object.left.relation.name.classify.constantize.columns.detect do |col|
+            matchable_column?(col, object)
+          end
 
-        if [:hstore, :jsonb].include?(left_column&.type)
-          visit_Arel_Nodes_ContainsHStore(object, collector)
-        elsif left_column.try(:array)
-          visit_Arel_Nodes_ContainsArray(object, collector)
-        else
-          visit_Arel_Nodes_Inet_Contains(object, collector)
+          if [:hstore, :jsonb].include?(left_column&.type)
+            visit_Arel_Nodes_ContainsHStore(object, collector)
+          elsif left_column.try(:array)
+            visit_Arel_Nodes_ContainsArray(object, collector)
+          else
+            visit_Arel_Nodes_Inet_Contains(object, collector)
+          end
         end
       end
 


### PR DESCRIPTION
Still need to figure out if we want to keep INET for Arel (just for the contains visitor method) or not (leaning towards no)