### PR TITLE
83 - support cte with values

### DIFF
--- a/lib/active_record_extended/utilities/support.rb
+++ b/lib/active_record_extended/utilities/support.rb
@@ -113,7 +113,7 @@ module ActiveRecordExtended
         case value.to_s
           # Ignore keys that contain double quotes or a Arel.star (*)[all columns]
           # or if a table has already been explicitly declared (ex: users.id)
-        when "*", /((^".+"$)|(^[[:alpha:]]+\.[[:alnum:]]+))/
+        when "*", /((^".+"$)|(^[[:alpha:]]+\.[[:alnum:]]+)|\(.+\))/
           value
         else
           PG::Connection.quote_ident(value.to_s)

--- a/spec/query_methods/with_cte_spec.rb
+++ b/spec/query_methods/with_cte_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe "Active Record With CTE Query Methods" do
         expect(query).to match_array([user_one, user_two])
       end
     end
+    
+    context "when creating using values" do
+      let!(:user_tommy) { User.create!(name: "tommy") }
+      let!(:user_jimmy) { User.create!(name: "jimmy") }
+
+      before do
+        User.create!(name: "diff")
+      end
+
+      it "returns only users with matching names from cte" do
+        cte = { "user_names(name)" => "values('jimmy'),('tommy'),('gummy')" }
+
+        query = User.with(cte)
+                    .joins("JOIN user_names ON users.name = user_names.name")
+                    .order(:name)
+
+        expect(query).to match_array([user_jimmy, user_tommy])
+      end
+    end
 
     context "when merging in query" do
       before do


### PR DESCRIPTION
Fixes: https://github.com/GeorgeKaraszi/ActiveRecordExtended/issues/83

Changes Summary:
Avoid quoting when cte name/key contains parentheses.

Testing steps:

Before:
```
cte = { "user_names(name)" => "values('jimmy'),('tommy'),('gummy')" }

 User.with(cte).joins("JOIN user_names ON users.name = user_names.name").order(:name).to_sql
=> "WITH \"user_names(name)\" AS (values('jimmy'),('tommy'),('gummy')) SELECT \"users\".* FROM \"users\" JOIN user_names ON users.name = user_names.name ORDER BY \"users\".\"name\" ASC"
```

After:

```
 User.with(cte).joins("JOIN user_names ON users.name = user_names.name").order(:name).to_sql
=> "WITH user_names(name) AS (values('jimmy'),('tommy'),('gummy')) SELECT \"users\".* FROM \"users\" JOIN user_names ON users.name = user_names.name ORDER BY \"users\".\"name\" ASC"
``` 