### PR TITLE
Bugfix: Prevent union from executing queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem "pry"
   gem "pry-byebug"
   gem "rails_sql_prettifier" # niceql
+  gem "rspec-sqlimit"
 end
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
     rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
+    rspec-sqlimit (0.0.5)
+      activerecord (> 4.2, < 7.1)
+      rspec (~> 3.0)
     rspec-support (3.12.0)
     rubocop (1.41.1)
       json (~> 2.3)
@@ -112,6 +115,7 @@ DEPENDENCIES
   rails_sql_prettifier
   rake (>= 10.0)
   rspec (~> 3.0)
+  rspec-sqlimit
   rubocop
   rubocop-performance
   rubocop-rake

--- a/lib/active_record_extended/query_methods/unionize.rb
+++ b/lib/active_record_extended/query_methods/unionize.rb
@@ -107,7 +107,7 @@ module ActiveRecordExtended
       end
 
       def union(opts = :chain, *args)
-        return UnionChain.new(spawn) if opts == :chain
+        return UnionChain.new(spawn) if :chain == opts
 
         opts.nil? ? self : spawn.union!(opts, *args, chain_method: __callee__)
       end
@@ -121,7 +121,7 @@ module ActiveRecordExtended
       def union!(opts = :chain, *args, chain_method: :union)
         union_chain    = UnionChain.new(self)
         chain_method ||= :union
-        return union_chain if opts == :chain
+        return union_chain if :chain == opts
 
         union_chain.public_send(chain_method, *([opts] + args))
       end

--- a/lib/active_record_extended/query_methods/with_cte.rb
+++ b/lib/active_record_extended/query_methods/with_cte.rb
@@ -155,19 +155,23 @@ module ActiveRecordExtended
 
       # @param [Hash, WithCTE] opts
       def with(opts = :chain, *rest)
-        return WithChain.new(spawn) if :chain == opts
+        return WithChain.new(spawn) if opts == :chain
 
         opts.blank? ? self : spawn.with!(opts, *rest)
       end
 
       # @param [Hash, WithCTE] opts
       def with!(opts = :chain, *rest)
-        return WithChain.new(self) if :chain == opts
-        return WithChain.new(self).recursive(*rest) if :recursive == opts
-
-        tap do |scope|
-          scope.cte ||= WithCTE.new(self)
-          scope.cte.pipe_cte_with!(opts)
+        case opts
+        when :chain
+          WithChain.new(self)
+        when :recursive
+          WithChain.new(self).recursive(*rest)
+        else
+          tap do |scope|
+            scope.cte ||= WithCTE.new(self)
+            scope.cte.pipe_cte_with!(opts)
+          end
         end
       end
 

--- a/lib/active_record_extended/query_methods/with_cte.rb
+++ b/lib/active_record_extended/query_methods/with_cte.rb
@@ -162,16 +162,12 @@ module ActiveRecordExtended
 
       # @param [Hash, WithCTE] opts
       def with!(opts = :chain, *rest)
-        case opts
-        when :chain
-          WithChain.new(self)
-        when :recursive
-          WithChain.new(self).recursive(*rest)
-        else
-          tap do |scope|
-            scope.cte ||= WithCTE.new(self)
-            scope.cte.pipe_cte_with!(opts)
-          end
+        return WithChain.new(self) if :chain == opts
+        return WithChain.new(self).recursive(*rest) if :recursive == opts
+
+        tap do |scope|
+          scope.cte ||= WithCTE.new(self)
+          scope.cte.pipe_cte_with!(opts)
         end
       end
 

--- a/lib/active_record_extended/query_methods/with_cte.rb
+++ b/lib/active_record_extended/query_methods/with_cte.rb
@@ -155,7 +155,7 @@ module ActiveRecordExtended
 
       # @param [Hash, WithCTE] opts
       def with(opts = :chain, *rest)
-        return WithChain.new(spawn) if opts == :chain
+        return WithChain.new(spawn) if :chain == opts
 
         opts.blank? ? self : spawn.with!(opts, *rest)
       end

--- a/rubocop/rubocop-styles.yml
+++ b/rubocop/rubocop-styles.yml
@@ -141,3 +141,6 @@ Style/SwapValues:
 
 Style/FetchEnvVar:
   Enabled: false
+
+Style/YodaCondition:
+  Enabled: false

--- a/spec/query_methods/unionize_spec.rb
+++ b/spec/query_methods/unionize_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe "Active Record Union Methods" do
       expect(query.pluck(:id)).to have_attributes(size: expected_ids.size).and(match_array(expected_ids))
     end
 
+    it "does not execute additional queries" do
+      expect do
+        GroupsUser.union(
+          user_one.groups_users,
+          user_two.groups_users
+        )
+      end.not_to exceed_query_limit(0)
+    end
+
     context "when merging in query" do
       it "will maintain the union table when merging into existing AR queries" do
         base_query  = User.union(User.where(id: user_one.id), User.joins(:profile_l).where.not(id: user_one.id))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "simplecov"
 SimpleCov.start
 
 require "active_record_extended"
+require "rspec-sqlimit"
 
 unless ENV["DATABASE_URL"]
   require "dotenv"


### PR DESCRIPTION
When doing an union like this:
```
GroupsUser.union(
  user.groups_users.where(id: 1),
  user.groups_users.where(id: 2),
)
```
The `opts == :chain` will check `user.groups_users.where(id: 1) == :opts` thus executing a query.
This is easily fixed by inverting the equality check order.

This was already fixed once in the past in https://github.com/GeorgeKaraszi/ActiveRecordExtended/pull/60