### PR TITLE
Remove upper limit for rails gems

### DIFF
--- a/active_record_extended.gemspec
+++ b/active_record_extended.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2"
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "activerecord", ">= 5.2", "< 8.1"
+  spec.add_dependency "activerecord", ">= 5.2"
   spec.add_dependency "pg", "< 3.0"
 end


### PR DESCRIPTION
Please rails 8.1 will be released in a week, and more and more companies are running on Rails edge/main as well.

could we normalize removing the upper limit on rails, and let people open issues if they ever use the rails latest version, or if maintainers of the gems add explicit support for newer versions, whichever comes first.

Thanks in advance!