### PR TITLE
add explicit rails 8.1 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     active_record_extended (3.4.0)
-      activerecord (>= 5.2, < 8.1)
+      activerecord (>= 7.0, < 8.2)
       pg (< 3.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Active Record Extended is essentially providing users with the other half of Pos
 
 This package is designed to align and work with any officially supported Ruby and Rails versions.
  - Minimum Ruby Version: 3.1.x **(EOL warning!)**
- - Minimum Rails Version: 6.1.x **(EOL warning!)**
+ - Minimum Rails Version: 7.0.x **(EOL warning!)**
  - Minimum Postgres Version: 12.x **(EOL warning!)**
  - Latest Ruby supported: 3.4.x
- - Latest Rails supported: 8.0.x
+ - Latest Rails supported: 8.1.x
  - Postgres: 11-current(18) (probably works with most older versions to a certain point)
 
 ## Installation

--- a/active_record_extended.gemspec
+++ b/active_record_extended.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2"
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.add_dependency "activerecord", ">= 5.2"
+  spec.add_dependency "activerecord", ">= 7.0"
   spec.add_dependency "pg", "< 3.0"
 end

--- a/gemfiles/activerecord-81.gemfile
+++ b/gemfiles/activerecord-81.gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+eval_gemfile "../Gemfile"
+
+gem "activerecord", "~> 8.1.0"
+gem "pg", "< 2.0"


### PR DESCRIPTION
this pr adds rails 8.1 support. 

locally i deleted `Gemfile.lock`, did a `bundle install`, and verified that the tests work.

i'm unsure why the `gemfiles` have `pg < 2.0` as a requirement - once the actions can run here i'm going to try removing this (the gemspec explicitly allows `pg < 3.0`). 

note that `rails 7.0` and `rails 7.1` are EOL'd and can probably be removed but i thought that was beyond the scope of this pr. 