### PR TITLE
CTE deep duplication on spawn and chaining

### DIFF
--- a/lib/active_record_extended/query_methods/with_cte.rb
+++ b/lib/active_record_extended/query_methods/with_cte.rb
@@ -44,7 +44,7 @@ module ActiveRecordExtended
         end
 
         # @param [Hash, WithCTE] value
-        def pipe_cte_with!(value) # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+        def pipe_cte_with!(value)
           return if value.nil? || value.empty?
 
           value.each_pair do |name, expression|
@@ -54,8 +54,6 @@ module ActiveRecordExtended
             # Ensure we follow FIFO pattern.
             # If the parent has similar CTE alias keys, we want to favor the parent's expressions over its children's.
             if expression.is_a?(ActiveRecord::Relation) && expression.with_values?
-              expression.cte = expression.cte.dup if expression.cte
-
               # Add child's materialized keys to the parent
               @materialized_keys += expression.cte.materialized_keys
               @not_materialized_keys += expression.cte.not_materialized_keys
@@ -77,13 +75,21 @@ module ActiveRecordExtended
           @materialized_keys = Set.new
           @not_materialized_keys = Set.new
         end
+
+        def deep_dup
+          @with_keys = @with_keys.deep_dup
+          @with_values = @with_values.deep_dup
+          @materialized_keys = @materialized_keys.deep_dup
+          @not_materialized_keys_keys = @not_materialized_keys_keys.deep_dup
+          super
+        end
       end
 
       class WithChain
         # @param [ActiveRecord::Relation] scope
         def initialize(scope)
-          @scope       = scope
-          @scope.cte ||= WithCTE.new(scope)
+          @scope     = scope
+          @scope.cte = @scope.cte&.deep_dup || WithCTE.new(scope)
         end
 
         # @param [Hash, WithCTE] args
@@ -118,6 +124,12 @@ module ActiveRecordExtended
             end
             scope.cte.pipe_cte_with!(args)
           end
+        end
+      end
+
+      def spawn
+        super.tap do |scope|
+          scope.cte = scope.cte.deep_dup if scope.cte
         end
       end
 

--- a/spec/query_methods/with_cte_spec.rb
+++ b/spec/query_methods/with_cte_spec.rb
@@ -82,5 +82,20 @@ RSpec.describe "Active Record With CTE Query Methods" do
         expect(user_relation_with_self_cte).to contain_exactly(user_one, user_two)
       end
     end
+
+    context "when called again will spawn the relation" do
+      it "maintains the CTE in the spawned relation" do
+        cte_hash = { profile: ProfileL.where("likes < 300") }
+        relation = User.all.with(cte_hash)
+        spawned_relation = relation.all
+        second_relation = relation.with.materialized(cte_hash)
+
+        expect(relation.cte.object_id).not_to eq(spawned_relation.cte.object_id)
+        expect(relation.to_sql).to eq(spawned_relation.to_sql)
+
+        expect(relation.cte.object_id).not_to eq(second_relation.cte.object_id)
+        expect(relation.to_sql).not_to eq(second_relation.to_sql)
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes some weird issues where using `.with` would affect all relations that had a `WithCTE`.