### PR TITLE
add contains keys methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ This only accepts a single value to a given attribute. So querying for example m
 [Postgres '@>' (JSONB/HSTORE type) Contains expression](https://www.postgresql.org/docs/10/static/functions-json.html#FUNCTIONS-JSONB-OP-TABLE)
 
 
-The `contains/1` method is used for finding any elements in an `Array`, `JSONB`, or `HSTORE` column type.
-That contains all of the provided values.
+The `contains/1` method is used for finding any elements in an `Array`, `JSONB`, or `HSTORE` column type that contains all of the provided values.
 
 Array Type:
 ```ruby
@@ -133,6 +132,23 @@ bob   = User.create!(data: { nickname: "ARExtended" })
 randy = User.create!(data: { nickname: "ARExtended" })
 
 User.where.contains(data: { nickname: "ARExtended" }) #=> [bob, randy]
+```
+
+#### Contains Key(s)
+[Postgres '@>' (JSONB/HSTORE type) Contains expression](https://www.postgresql.org/docs/10/static/functions-json.html#FUNCTIONS-JSONB-OP-TABLE)
+
+
+The `contains_key/1`, `contains_any_key/2`, and `contains_all_keys/2` methods are used for finding any elements in a `JSONB` or `HSTORE` column type that contains the provided key, any of the provided keys, or all of the provided keys, respectively.
+
+HSTORE / JSONB Type:
+```ruby
+alice = User.create!(data: { nickname: "ARExtend", alias: "al" })
+bob   = User.create!(data: { nickname: "ARExtended", email: "bob@gmail.com" })
+randy = User.create!(data: { nickname: "ARExtended" })
+
+User.where.contains_key(data: "nickname") #=> [alice, bob, randy]
+User.where.contains_any_key(data: ["alias", "email"]) #=> [alice, bob]
+User.where.contains_all_keys(data: ["alias", "nickname"]) #=> [alice]
 ```
 
 #### Overlap

--- a/lib/active_record_extended/arel/predications.rb
+++ b/lib/active_record_extended/arel/predications.rb
@@ -23,6 +23,18 @@ module Arel
       Nodes::Contains.new self, Nodes.build_quoted(other, self)
     end
 
+    def contains_key(other)
+      Nodes::ContainsKey.new self, Nodes.build_quoted(other, self)
+    end
+
+    def contains_any_key(other)
+      Nodes::ContainsAnyKey.new self, Nodes.build_quoted(other, self)
+    end
+
+    def contains_all_keys(other)
+      Nodes::ContainsAllKeys.new self, Nodes.build_quoted(other, self)
+    end
+
     def contained_in_array(other)
       Nodes::ContainedInArray.new self, Nodes.build_quoted(other, self)
     end

--- a/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
+++ b/lib/active_record_extended/arel/visitors/postgresql_decorator.rb
@@ -20,6 +20,18 @@ module ActiveRecordExtended
         infix_value object, collector, " <@ "
       end
 
+      def visit_Arel_Nodes_ContainsKey(object, collector)
+        infix_value object, collector, " ? "
+      end
+
+      def visit_Arel_Nodes_ContainsAnyKey(object, collector)
+        infix_value object, collector, " ?| "
+      end
+
+      def visit_Arel_Nodes_ContainsAllKeys(object, collector)
+        infix_value object, collector, " ?& "
+      end
+
       def visit_Arel_Nodes_ContainedInArray(object, collector)
         infix_value object, collector, " <@ "
       end

--- a/lib/active_record_extended/query_methods/where_chain.rb
+++ b/lib/active_record_extended/query_methods/where_chain.rb
@@ -49,6 +49,18 @@ module ActiveRecordExtended
         substitute_comparisons(opts, rest, Arel::Nodes::Contains, "contains")
       end
 
+      def contains_key(opts, *rest)
+        substitute_comparisons(opts, rest, Arel::Nodes::ContainsKey, "contains_key")
+      end
+
+      def contains_any_key(opts, *rest)
+        substitute_comparisons(opts, rest, Arel::Nodes::ContainsAnyKey, "contains_any_key")
+      end
+
+      def contains_all_keys(opts, *rest)
+        substitute_comparisons(opts, rest, Arel::Nodes::ContainsAllKeys, "contains_all_keys")
+      end
+
       private
 
       def matchable_column?(col, arel)

--- a/spec/query_methods/hash_query_spec.rb
+++ b/spec/query_methods/hash_query_spec.rb
@@ -42,4 +42,118 @@ RSpec.describe "Active Record Hash Related Query Methods" do
       end
     end
   end
+
+  describe "#contains_key" do
+    context "with HStore Column Type" do
+      it "returns records that contain the hash key in joined tables" do
+        four = User.create!(data: { alias: "four" })
+
+        query = Tag.joins(:user).where.contains_key(users: { data: "nickname" })
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+
+      it "returns records that contain the hash key" do
+        four = User.create!(data: { alias: "four" })
+
+        query = User.where.contains_key(data: "nickname")
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+    end
+
+    context "with JSONB Column Type" do
+      it "returns records that contain the hash key in joined tables" do
+        four = User.create!(jsonb_data: { alias: "four" })
+
+        query = Tag.joins(:user).where.contains_key(users: { jsonb_data: "nickname" })
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+
+      it "returns records that contain the hash key" do
+        four = User.create!(jsonb_data: { alias: "four" })
+
+        query = User.where.contains_key(jsonb_data: "nickname")
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+    end
+  end
+
+  describe "#contains_any_key" do
+    context "with HStore Column Type" do
+      it "returns records that contain the hash key in joined tables" do
+        four = User.create!(data: { alias: "four" })
+
+        query = Tag.joins(:user).where.contains_any_key(users: { data: ["nickname"] })
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+
+      it "returns records that contain the hash key" do
+        four = User.create!(data: { alias: "four" })
+
+        query = User.where.contains_any_key(data: ["nickname"])
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+    end
+
+    context "with JSONB Column Type" do
+      it "returns records that contain the hash key in joined tables" do
+        four = User.create!(jsonb_data: { alias: "four" })
+
+        query = Tag.joins(:user).where.contains_any_key(users: { jsonb_data: ["nickname"] })
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+
+      it "returns records that contain the hash key" do
+        four = User.create!(jsonb_data: { alias: "four" })
+
+        query = User.where.contains_any_key(jsonb_data: ["nickname"])
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+    end
+  end
+
+  describe "#contains_all_keys" do
+    context "with HStore Column Type" do
+      it "returns records that contain the hash key in joined tables" do
+        four = User.create!(data: { alias: "four" })
+
+        query = Tag.joins(:user).where.contains_all_keys(users: { data: ["nickname"] })
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+
+      it "returns records that contain the hash key" do
+        four = User.create!(data: { alias: "four" })
+
+        query = User.where.contains_all_keys(data: ["nickname"])
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+    end
+
+    context "with JSONB Column Type" do
+      it "returns records that contain the hash key in joined tables" do
+        four = User.create!(jsonb_data: { alias: "four" })
+
+        query = Tag.joins(:user).where.contains_all_keys(users: { jsonb_data: ["nickname"] })
+        expect(query).to include(one, two, three)
+        expect(query).not_to include(four)
+      end
+
+      it "returns records that contain the hash key" do
+        four = User.create!(jsonb_data: { nickname: "george", alias: "four" })
+
+        query = User.where.contains_all_keys(jsonb_data: ["nickname", "alias"])
+        expect(query).to include(four)
+        expect(query).not_to include(one, two, three)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds support for the `?`, `?|`, and `?&` operators. The corresponding query methods are named `contains_key`, `contains_any_key`, and `contains_all_keys`, respectively. 

I'm shooting from the hip a bit, as I don't have a local test harness that makes this simple to test. 