### PR TITLE
Fix ArrayHandlerPatch to support multi-database configurations

### DIFF
--- a/lib/active_record_extended/patch/array_handler_patch.rb
+++ b/lib/active_record_extended/patch/array_handler_patch.rb
@@ -7,7 +7,18 @@ module ActiveRecordExtended
   module Patch
     module ArrayHandlerPatch
       def call(attribute, value)
-        cache = ActiveRecord::Base.connection.schema_cache
+        # Resolve the connection through the model that owns the Arel table,
+        # rather than hardcoding ActiveRecord::Base.connection. In multi-database
+        # setups (Rails 6.1+), ActiveRecord::Base may not have a connection pool
+        # registered — pools are on the abstract classes that declare connects_to.
+        #
+        # Arel::Table stores the owning model as @klass (set via the klass:
+        # keyword argument in its constructor). There is no public accessor,
+        # so we use instance_variable_get with a fallback to ActiveRecord::Base
+        # for cases where klass is nil (e.g. hand-built Arel tables).
+        klass = attribute.relation.instance_variable_get(:@klass) || ActiveRecord::Base
+        cache = klass.connection.schema_cache
+
         if cache.data_source_exists?(attribute.relation.name)
           column = cache.columns(attribute.relation.name).detect { |col| col.name.to_s == attribute.name.to_s }
           return attribute.eq(value) if column.try(:array)


### PR DESCRIPTION
## Problem

`ArrayHandlerPatch#call` hardcodes `ActiveRecord::Base.connection` to check the schema cache for PostgreSQL array columns. In Rails 6.1+ multi-database setups where `connects_to` is declared on abstract subclasses (not `ActiveRecord::Base` itself), `ActiveRecord::Base` has no connection pool registered. This raises `ActiveRecord::ConnectionNotDefined` on any `.where()` with array values.

Minimal reproduction:

```rb
class ApplicationRecord < ActiveRecord::Base
  primary_abstract_class
  connects_to database: { writing: :primary, reading: :primary_replica }
end

# Any model with an array column:
Role.where(name: ["admin", "doctor"])
# => ActiveRecord::ConnectionNotDefined: No database connection defined.
```

## Fix

Resolve the connection through the model that owns the Arel table, via `attribute.relation`. Arel::Table stores the owning model as `@klass` (set via the `klass:` keyword argument in its constructor). There is no public accessor,
so we use `instance_variable_get(:@klass)` with a fallback to `ActiveRecord::Base` for cases where klass is nil (e.g. hand-built Arel tables).

This is the minimal change — the rest of the method is untouched.

## Notes

- Verified on Rails 8.0.3 with PostgreSQL and a multi-database config (separate primary + queue databases)
- The fallback to `ActiveRecord::Base` preserves existing behavior for single-database setups
- `@klass` has been present on `Arel::Table` since Rails 5.2 and is used internally by Rails for attribute alias resolution